### PR TITLE
Version 2.2.3 improvements

### DIFF
--- a/.env.default.urls
+++ b/.env.default.urls
@@ -1,0 +1,52 @@
+##############################################################################
+# Overview:
+#
+# This file contains the school-dependent URLs for source pull websites.
+# It is set up to work with The University of Texas School of Law's login
+# system, so you will need to change these values if you are running Coyote
+# Badger from somewhere else.
+#
+# To change these values, duplicate this file into the same folder it's in
+# and rename the duplicate from `.env.default.urls` to `.env.custom.urls`.
+# Then modify the values and save the file. On the next start up of Coyote
+# Badger, it will use your new values.
+#
+# This `.env.default.urls` file is shared in the git repository but
+# the `.env.custom.urls` file is ignored, allowing individuals to edit
+# these values without affecting other users.
+##############################################################################
+
+##############################################################################
+# URLs for HeinOnline
+# - HEIN_SIGN_IN_URL is the page where you enter your username and password
+# - HEIN_AUTHED_URL is the landing page after you successfully log in
+# - HEIN_SEARCH_URL is the URL when you make a citation search on Hein (note
+#   that this string should have a {} in the `cit_string` query parameter)
+# - HEIN_BASE URL is the base URL of your organization's Hein subscription
+##############################################################################
+HEIN_SIGN_IN_URL="https://heinonline.org/HOL/WAYFless?entityID=https%3A%2F%2Fidp.utexas.edu%2Fopenathens&target=https%3A%2F%2Fwww.heinonline.org%2FHOL%2FWelcome"
+HEIN_AUTHED_URL="https://heinonline.org/HOL/Welcome"
+HEIN_SEARCH_URL="https://heinonline.org/HOL/OneBoxCitation?cit_string={}&searchtype=advanced&typea=citation&other_cols=yes&submit=Go&sendit="
+HEIN_BASE_URL="https://heinonline.org/HOL/"
+
+##############################################################################
+# URLs for Westlaw
+# - WESTLAW_SIGN_IN_URL is the page where you enter your username and password
+# - WESTLAW_AUTHED_URL is the landing page after you successfully log in
+# - WESTLAW_SEARCH_URL is the page where you enter a search query on Westlaw
+# - WESTLAW_STATUTES_URL is the page where you search Statutes
+# - WESTLAW_CASES_URL is the page where you search Cases
+##############################################################################
+WESTLAW_SIGN_IN_URL="https://lawschool.westlaw.com/redirect/westlaw"
+WESTLAW_AUTHED_URL="https://1.next.westlaw.com/Search/Home.html?transitionType=Default&contextData=(sc.Default)"
+WESTLAW_SEARCH_URL="https://1.next.westlaw.com/Search/Home.html?transitionType=Default&contextData=(sc.Default)"
+WESTLAW_STATUTES_URL="https://1.next.westlaw.com/Browse/Home/StatutesCourtRules?transitionType=Default&contextData=(sc.Default)"
+WESTLAW_CASES_URL="https://1.next.westlaw.com/Browse/Home/Cases?transitionType=Default&contextData=(sc.Default)"
+
+##############################################################################
+# URLs for SSRN
+# - SSRN_SIGN_IN_URL is the page where you enter your username and password
+# - SSRN_AUTHED_URL is the landing page after you successfully log in
+##############################################################################
+SSRN_SIGN_IN_URL="https://hq.ssrn.com/login/pubsigninjoin.cfm"
+SSRN_AUTHED_URL="https://hq.ssrn.com/Library/myLibrary.cfm"

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ coyote_badger/usr/
 _projects/*
 _projects/**/*
 !_projects/.gitkeep
-.env.custom.*
+settings.custom.*
 external
 .DS_Store
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,9 @@ coyote_badger/usr/
 _projects/*
 _projects/**/*
 !_projects/.gitkeep
+.env.custom.*
 external
 .DS_Store
-
 
 ###Python###
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,14 +21,6 @@ RUN apt-get update && apt-get install -y \
 RUN python3 --version
 RUN pip3 --version
 
-# Install package requirements from PyPI
-COPY requirements.txt requirements.txt
-RUN pip3 install -r requirements.txt
-
-# Install playwright browsers
-RUN playwright install chromium firefox
-RUN playwright install-deps chromium firefox
-
 # Install XFCE4 and TigerVNC to run browsers in headful mode
 RUN apt-get update && apt-get install -y \
     xfce4 \
@@ -55,6 +47,14 @@ ENV XFCE_PANEL_MIGRATE_DEFAULT 1
 ADD xfce4/noVNC_full.html noVNC/index.html
 ADD xfce4/noVNC_ui.js noVNC/app/ui.js
 
+# Install package requirements from PyPI
+COPY requirements.txt requirements.txt
+RUN pip3 install -r requirements.txt
+
+# Install playwright browsers
+RUN playwright install chromium firefox
+RUN playwright install-deps chromium firefox
+
 # For debugging
 RUN pip3 freeze
 
@@ -62,6 +62,7 @@ RUN pip3 freeze
 COPY coyote_badger coyote_badger
 COPY xfce4 xfce4
 COPY docker.sh docker.sh
+COPY .env.default.* .env.custom.* ./
 
 # Run the boot up script
 RUN chmod +x docker.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,7 @@ RUN pip3 freeze
 COPY coyote_badger coyote_badger
 COPY xfce4 xfce4
 COPY docker.sh docker.sh
-COPY .env.default.* .env.custom.* ./
+COPY settings.default.* settings.custom.* ./
 
 # Run the boot up script
 RUN chmod +x docker.sh

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ update your version:
 1. Stop Coyote Badger using the `__MAC-STOP.command` or `__WINDOWS-STOP.bat`
    files.
 2. Copy the `_projects` folder if you want to save your previous projects.
-3. Copy the `.env.custom.urls` file if you created one to use custom login URLs.
+3. Copy the `settings.custom.urls` file if you created one to use custom login URLs.
 4. Delete your Coyote Badger folder.
 5. Download the latest "Source code (zip)" of Coyote Badger from
    [here](https://github.com/alexsands/coyote-badger/releases/latest).
@@ -119,7 +119,7 @@ update your version:
    remember (e.g., `Documents` folder). You can rename the containing folder
    if you'd like.
 6. Restore your `_projects` folder if you backed it up in step 2.
-7. Restore your `.env.custom.urls` file if you backed it up in step 3.
+7. Restore your `settings.custom.urls` file if you backed it up in step 3.
 8. That's it! Now you can [run Coyote Badger](#run).
 
 
@@ -274,14 +274,14 @@ source pull websites. By default, it is set up to work with The University of
 Texas School of Law's login system, so you will need to change these values
 if you are running Coyote Badger from somewhere else.
 
-To change these values, duplicate the `.env.default.urls` file in the root
-folder (keep it in the same file). Rename the duplicate to `.env.custom.urls`
+To change these values, duplicate the `settings.default.urls` file in the root
+folder (keep it in the same file). Rename the duplicate to `settings.custom.urls`
 (note, the file should start with a period, exactly as shown). Then, open up
 your duplicated file, modify the values, and save the file. On the next start
 up of Coyote Badger, it will use your new values.
 
 When you install a new version of Coyote Badger, just drop your
-`.env.custom.urls` file into the new version.
+`settings.custom.urls` file into the new version.
 
 
 #### Hein login seems to always fail because my Duo isn't working. What do I do?

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
       - [Mac (Intel or Apple Silicon)](#mac-intel-or-apple-silicon)
       - [Windows](#windows)
   - [Update](#update)
+    - [Automatic Update](#automatic-update)
+    - [Manual Update](#manual-update)
   - [Development](#development)
     - [Running from Source in Docker](#running-from-source-in-docker)
     - [Running from Source in Python](#running-from-source-in-python)
@@ -106,8 +108,17 @@ system:
 ## Update
 Please make sure to update to the newest version of Coyote Badger when it is
 released. The content and layout of these websites changes somewhat regularly
-so if you're experiencing issues, it may get fixed in a future release. To
-update your version:
+so if you're experiencing issues, it may get fixed in a future release. You
+can update your Coyote Badger software manually or automatically
+(starting with version `2.2.3`). Automatic updates will save your `_projects`
+folder and your custom variables—you do not need to back these up yourself.
+
+### Automatic Update
+1. Open the `__MAC-UPDATE.command` or `__WINDOWS-UPDATE.bat` file.
+2. Press any key on your keyboard when prompted.
+3. Wait for the update to complete.
+
+### Manual Update
 1. Stop Coyote Badger using the `__MAC-STOP.command` or `__WINDOWS-STOP.bat`
    files.
 2. Copy the `_projects` folder if you want to save your previous projects.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
       - [Docker is taking up a lot of space on my computer. What should I do?](#docker-is-taking-up-a-lot-of-space-on-my-computer-what-should-i-do)
       - [Coyote Badger is suddenly failing on a specific type of source. What do I do?](#coyote-badger-is-suddenly-failing-on-a-specific-type-of-source-what-do-i-do)
       - [Everything is installed, it's running, but the actual Coyote Badger application isn't pulling sources properly. What do I do?](#everything-is-installed-its-running-but-the-actual-coyote-badger-application-isnt-pulling-sources-properly-what-do-i-do)
+      - [I use a different login to access the source pulling websites. How do I add my custom URLs?](#i-use-a-different-login-to-access-the-source-pulling-websites-how-do-i-add-my-custom-urls)
       - [Hein login seems to always fail because my Duo isn't working. What do I do?](#hein-login-seems-to-always-fail-because-my-duo-isnt-working-what-do-i-do)
       - [My HeinOnline account was deactivated because of dowload activity. What should I do?](#my-heinonline-account-was-deactivated-because-of-dowload-activity-what-should-i-do)
       - [Why use `headless=False` with `xvfb` if you can't even see the browser?](#why-use-headlessfalse-with-xvfb-if-you-cant-even-see-the-browser)
@@ -110,14 +111,16 @@ update your version:
 1. Stop Coyote Badger using the `__MAC-STOP.command` or `__WINDOWS-STOP.bat`
    files.
 2. Copy the `_projects` folder if you want to save your previous projects.
-3. Delete your Coyote Badger folder.
-4. Download the latest "Source code (zip)" of Coyote Badger from
+3. Copy the `.env.custom.urls` file if you created one to use custom login URLs.
+4. Delete your Coyote Badger folder.
+5. Download the latest "Source code (zip)" of Coyote Badger from
    [here](https://github.com/alexsands/coyote-badger/releases/latest).
    Then unzip the file and move it to somewhere on your computer that you'll
    remember (e.g., `Documents` folder). You can rename the containing folder
    if you'd like.
-5. Restore your `_projects` folder if you backed it up in step 2.
-6. That's it! Now you can [run Coyote Badger](#run).
+6. Restore your `_projects` folder if you backed it up in step 2.
+7. Restore your `.env.custom.urls` file if you backed it up in step 3.
+8. That's it! Now you can [run Coyote Badger](#run).
 
 
 ## Development
@@ -261,6 +264,24 @@ broke the automated puller. If you are familiar with programming, you can try
 to fix this on your own with the [Development](#development) instructions and
 then make an issue/pull request on GitHub. Otherwise, please read the
 [Making or Requesting Changes](#making-or-requesting-changes) section.
+
+
+#### I use a different login to access the source pulling websites. How do I add my custom URLs?
+
+Coyote Badger logs you in to different source pulling sites to gather sources
+using your account credentials. The program contains school-dependent URLs for
+source pull websites. By default, it is set up to work with The University of
+Texas School of Law's login system, so you will need to change these values
+if you are running Coyote Badger from somewhere else.
+
+To change these values, duplicate the `.env.default.urls` file in the root
+folder (keep it in the same file). Rename the duplicate to `.env.custom.urls`
+(note, the file should start with a period, exactly as shown). Then, open up
+your duplicated file, modify the values, and save the file. On the next start
+up of Coyote Badger, it will use your new values.
+
+When you install a new version of Coyote Badger, just drop your
+`.env.custom.urls` file into the new version.
 
 
 #### Hein login seems to always fail because my Duo isn't working. What do I do?

--- a/__MAC-UPDATE.command
+++ b/__MAC-UPDATE.command
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+cd -- "$(dirname "$0")"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+echo -e "${CYAN}This script will update Coyote Badger to the newest version.${NC}"
+echo -e "${CYAN}All of your past projects and custom settings will be saved.${NC}"
+echo -e "${CYAN}This update may take a minute. Do not close this window while the update is in progress.${NC}"
+echo -e "${YELLOW}Press any key to continue...${NC}"
+read -n 1 -s -r key
+
+./__MAC-STOP.command
+curl -L https://api.github.com/repos/alexsands/coyote-badger/zipball > cb_next.tar.gz
+tar -xzvf "cb_next.tar.gz"
+mv alexsands-coyote-badger-* cb_next/
+rm -rf cb_next/_projects
+cp -r cb_next/* .
+rm -rf cb_next/
+rm -rf cb_next.tar.gz
+
+echo -e "${GREEN}Coyote Badger is now up to date.${NC}"
+echo -e "${YELLOW}Press any key to close this window...${NC}"
+read -n 1 -s -r key
+exit

--- a/__WINDOWS-UPDATE.bat
+++ b/__WINDOWS-UPDATE.bat
@@ -1,0 +1,18 @@
+@ECHO OFF
+
+echo "This script will update Coyote Badger to the newest version."
+echo "All of your past projects and custom settings will be saved."
+echo "This update may take a minute. Do not close this window while the update is in progress."
+pause
+
+call __WINDOWS-STOP.bat
+curl -L "https://api.github.com/repos/alexsands/coyote-badger/tarball" -o "cb_next.tar.gz"
+tar -xzvf "cb_next.tar.gz"
+move "alexsands-coyote-badger-*" "cb_next"
+rmdir /s /q "cb_next\_projects"
+xcopy /s /e /h /y "cb_next\*" "."
+rmdir /s /q "cb_next"
+del /q "cb_next.tar.gz"
+
+echo "Coyote Badger is now up to date."
+pause

--- a/coyote_badger/config.py
+++ b/coyote_badger/config.py
@@ -10,4 +10,4 @@ PORT = 3000
 SEGMENT_WRITE_KEY = "JaFBSHlhMcRfjCovHfFVHIuN5TAj2WkL"
 
 REPO = "alexsands/coyote-badger"
-VERSION = "2.2.2"
+VERSION = "2.2.3"

--- a/coyote_badger/puller.py
+++ b/coyote_badger/puller.py
@@ -87,6 +87,7 @@ class Puller(object):
                     "Chrome/98.0.4758.102 Safari/537.36"
                 ),
                 chromium_sandbox=False,
+                ignore_https_errors=True,
                 ignore_default_args=[
                     "--enable-automation",
                 ],
@@ -121,6 +122,7 @@ class Puller(object):
                     "Gecko/20100101 Firefox/97.0"
                 ),
                 chromium_sandbox=False,
+                ignore_https_errors=True,
                 ignore_default_args=[
                     "--enable-automation",
                 ],

--- a/coyote_badger/puller.py
+++ b/coyote_badger/puller.py
@@ -15,8 +15,8 @@ from coyote_badger.source import Kind, Result
 
 class Puller(object):
     URLS = {
-        **dotenv_values(".env.default.urls"),
-        **dotenv_values(".env.custom.urls"),
+        **dotenv_values("settings.default.urls"),
+        **dotenv_values("settings.custom.urls"),
     }
     BROWSER_USER_DATA_DIR = os.path.join(PACKAGE_FOLDER, "usr")
     CHROME_USER_DATA_DIR = os.path.join(BROWSER_USER_DATA_DIR, "chrome")

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,6 +37,7 @@ pre-commit==2.20.0
 pyee==8.1.0
 PyPDF2==1.26.0
 python-dateutil==2.8.2
+python-dotenv==1.0.1
 PyYAML==6.0
 requests==2.28.1
 sanitize-filename==1.2.0

--- a/settings.default.urls
+++ b/settings.default.urls
@@ -7,12 +7,13 @@
 # Badger from somewhere else.
 #
 # To change these values, duplicate this file into the same folder it's in
-# and rename the duplicate from `.env.default.urls` to `.env.custom.urls`.
-# Then modify the values and save the file. On the next start up of Coyote
-# Badger, it will use your new values.
+# and rename the duplicate from `settings.default.urls` to
+# `settings.custom.urls`. Then modify the values inside the quotations below
+# and save the file. On the next start up of Coyote Badger, it will use your
+# new values.
 #
-# This `.env.default.urls` file is shared in the git repository but
-# the `.env.custom.urls` file is ignored, allowing individuals to edit
+# This `settings.default.urls` file is shared in the git repository but
+# the `settings.custom.urls` file is ignored, allowing individuals to edit
 # these values without affecting other users.
 ##############################################################################
 


### PR DESCRIPTION
- Fixes issue with HeinOnline SSL errors by ignore HTTPS errors in Playwright browsers
- Adds a new way of storing your custom source puller URLs
- Adds an automatic update feature